### PR TITLE
Update className type in MagicContainerProps

### DIFF
--- a/apps/web/registry/default/ui/magic-card.tsx
+++ b/apps/web/registry/default/ui/magic-card.tsx
@@ -32,7 +32,7 @@ function useMousePosition(): MousePosition {
 
 interface MagicContainerProps {
    children?: ReactNode
-   className?: any
+   className?: string
 }
 
 function MagicContainer({ children, className }: MagicContainerProps) {

--- a/apps/web/registry/miami/ui/magic-card.tsx
+++ b/apps/web/registry/miami/ui/magic-card.tsx
@@ -32,7 +32,7 @@ function useMousePosition(): MousePosition {
 
 interface MagicContainerProps {
    children?: ReactNode
-   className?: any
+   className?: string
 }
 
 function MagicContainer({ children, className }: MagicContainerProps) {


### PR DESCRIPTION
This PR updates the type of the className prop in MagicContainerProps from 'any' to 'string' in both the default and miami registry magic-card components.